### PR TITLE
feat: CI hardening, plugin contract validation, and developer task runner

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,139 @@
+name: Docker Build & Publish
+
+on:
+  release:
+    types: [published]
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: authkits/authkit.server
+  LOCAL_TAG: authkit-server:test
+
+jobs:
+  build:
+    name: Build Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (local, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: ${{ env.LOCAL_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Save image artifact
+        run: docker save ${{ env.LOCAL_TAG }} | gzip > /tmp/image.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp/image.tar.gz
+          retention-days: 1
+
+  test:
+    name: Smoke Test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load < /tmp/image.tar.gz
+
+      - name: Run container
+        run: docker run -d -p 8080:80 --name authkit ${{ env.LOCAL_TAG }}
+
+      - name: Wait for startup
+        run: sleep 15
+
+      - name: Verify container is running
+        run: |
+          STATE=$(docker inspect -f '{{.State.Running}}' authkit)
+          if [ "$STATE" != "true" ]; then
+            echo "Container is not running"
+            docker logs authkit
+            exit 1
+          fi
+
+      - name: Show logs
+        if: always()
+        run: docker logs authkit
+
+      - name: HTTP smoke check
+        run: |
+          curl -fsS http://localhost:8080/ -o /dev/null \
+            && echo "HTTP OK" \
+            || echo "No HTTP endpoint (non-fatal)"
+
+      - name: Stop container
+        if: always()
+        run: docker stop authkit || true
+
+  publish:
+    name: Publish to GHCR
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          provenance: true
+          sbom: true

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -1,0 +1,58 @@
+name: Plugin Contract Validation
+
+on:
+  push:
+    branches: [main, development]
+    tags: ['v*']
+    paths:
+      - 'src/Plugins/**'
+      - 'tools/PluginContractValidator/**'
+      - '.github/workflows/plugin-validation.yml'
+  pull_request:
+    branches: [main, development]
+    paths:
+      - 'src/Plugins/**'
+      - 'tools/PluginContractValidator/**'
+      - '.github/workflows/plugin-validation.yml'
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  VALIDATOR_PROJECT: 'tools/PluginContractValidator/PluginContractValidator.csproj'
+  PLUGINS_STAGING: 'out/plugins'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Plugin Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish plugins
+        run: |
+          mkdir -p "${{ env.PLUGINS_STAGING }}"
+          for proj in $(find src/Plugins -name '*.csproj' \
+              -not -path '*/Abstractions/*' \
+              -not -path '*/obj/*' \
+              -not -path '*/bin/*'); do
+            name=$(basename "$proj" .csproj)
+            echo "Publishing plugin: $name"
+            dotnet publish "$proj" -c Release -o "${{ env.PLUGINS_STAGING }}/$name" --nologo
+          done
+
+      - name: Build contract validator
+        run: dotnet build "${{ env.VALIDATOR_PROJECT }}" -c Release --nologo
+
+      - name: Run contract validation
+        run: |
+          VALIDATOR_DLL="tools/PluginContractValidator/bin/Release/net10.0/PluginContractValidator.dll"
+          dotnet "$VALIDATOR_DLL" "${{ github.workspace }}/${{ env.PLUGINS_STAGING }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,204 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  SOLUTION_FILE: 'AuthKit.slnx'
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  id-token: write
+  attestations: write
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+
+      - name: Run NuGet vulnerability scan
+        run: |
+          dotnet tool install --global NuGetAuditor
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          NuGetAuditor audit --format json --output audit-results.json
+
+      - name: Upload vulnerability results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: audit-results.json
+          category: nuget-audit
+
+  codeql-analysis:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          queries: security-extended,security-and-quality
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build solution
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration Release --no-restore
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: main
+          head: HEAD
+
+  license-check:
+    name: License Compliance
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+
+      - name: Check licenses
+        run: |
+          dotnet tool install --global dotnet-license-scanner
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet-license-scanner scan --solution ${{ env.SOLUTION_FILE }} --output licenses.json --fail-on-unapproved
+
+      - name: Upload license report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: license-report
+          path: licenses.json
+
+  sbom-generation:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+
+      - name: Build solution
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration Release --no-restore
+
+      - name: Generate SBOM
+        uses: ansible/sbom-action@v1
+        with:
+          path: .
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          sbom-path: sbom.spdx.json
+
+  container-scan:
+    name: Container Scan
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && hashFiles('**/Dockerfile') != ''
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -t authkit-server:latest -f Dockerfile .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'authkit-server:latest'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: container-scan
+
+  dotnet-format:
+    name: Code Style Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Check code formatting
+        run: dotnet format ${{ env.SOLUTION_FILE }} --verify-no-changes --verbosity diagnostic

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /certs/devcert.pfx
+.obsidian/
 bin/
 obj/
 /plugins/
+/out/
 .idea/
 .env
 /net-commander

--- a/AuthKit.slnx
+++ b/AuthKit.slnx
@@ -11,6 +11,9 @@
   <Folder Name="/Plugins/Solutions/">
     <Project Path="src/Plugins/Solutions/DevTokens/DevTokens.csproj" />
   </Folder>
+  <Folder Name="/Tools/">
+    <Project Path="tools/PluginContractValidator/PluginContractValidator.csproj" />
+  </Folder>     
   <Project Path="src/Core/Core.csproj" />
   <Project Path="src/Host/Host.csproj" />
 </Solution>

--- a/Taskfile.docker.yml
+++ b/Taskfile.docker.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+tasks:
+  build:
+    desc: Build the Docker image locally (no push)
+    cmds:
+      - docker build -t {{.IMAGE}}:dev -f Dockerfile .
+
+  run:
+    desc: Run the container locally on :8080
+    deps: [build]
+    cmds:
+      - docker run --rm -p 8080:80 --name authkit-local {{.IMAGE}}:dev
+
+  test:
+    desc: Smoke test the built image (start, log, stop)
+    deps: [build]
+    cmds:
+      - |
+        docker run -d -p 8080:80 --name authkit-smoke {{.IMAGE}}:dev
+        sleep 15
+        docker logs authkit-smoke
+        curl -fsS http://localhost:8080/ >/dev/null && echo "HTTP OK" || echo "no HTTP endpoint (non-fatal)"
+        docker stop authkit-smoke || true
+
+  publish:
+    desc: Build multi-arch image and push to GHCR
+    preconditions:
+      - sh: command -v docker >/dev/null && docker buildx version >/dev/null 2>&1
+        msg: "docker and docker buildx are required"
+    prompt: "Push {{.REGISTRY}}/{{.IMAGE}}:{{.VERSION}} to GHCR? Requires docker login."
+    cmds:
+      - docker buildx build --push --platform linux/amd64,linux/arm64 -t {{.REGISTRY}}/{{.IMAGE}}:latest -t {{.REGISTRY}}/{{.IMAGE}}:{{.VERSION}} -f Dockerfile .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,131 @@
+version: '3'
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+  DOTNET_NOLOGO: '1'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
+  REGISTRY: ghcr.io
+  IMAGE: authkits/authkit.server
+
+vars:
+  SOLUTION: AuthKit.slnx
+  HOST_PROJECT: src/Host/Host.csproj
+  PLUGINS_DIR: src/Plugins
+  VALIDATOR:
+    sh: echo tools/PluginContractValidator
+  VERSION:
+    sh: git describe --tags --always 2>/dev/null || echo dev
+
+tasks:
+  default:
+    desc: List all available tasks
+    cmds:
+      - task --list
+    silent: true
+
+  restore:
+    desc: Restore NuGet dependencies
+    preconditions:
+      - sh: command -v dotnet >/dev/null
+        msg: "dotnet SDK is required (https://dot.net)"
+    sources:
+      - '**/*.csproj'
+      - '{{.SOLUTION}}'
+      - Directory.Packages.props
+    generates:
+      - '**/obj/project.assets.json'
+    cmds:
+      - dotnet restore {{.SOLUTION}}
+
+  build:
+    desc: Build the solution in Release
+    deps: [restore]
+    sources:
+      - 'src/**/*.cs'
+      - '**/*.csproj'
+    generates:
+      - 'src/Host/bin/**'
+    cmds:
+      - dotnet build {{.SOLUTION}} --configuration Release --no-restore
+
+  test:
+    desc: Run the test suite
+    deps: [build]
+    cmds:
+      - dotnet test {{.SOLUTION}} --configuration Release --no-build
+
+  test:watch:
+    desc: Run tests and re-run on file changes
+    deps: [build]
+    watch: true
+    cmds:
+      - dotnet test {{.SOLUTION}} --configuration Release --no-build
+
+  format:
+    desc: Verify code formatting (fails if changes required)
+    cmds:
+      - dotnet format {{.SOLUTION}} --verify-no-changes
+
+  format:fix:
+    desc: Apply code formatting in place
+    cmds:
+      - dotnet format {{.SOLUTION}}
+
+  security:audit:
+    desc: List vulnerable NuGet packages (incl. transitive)
+    cmds:
+      - dotnet list {{.SOLUTION}} package --vulnerable --include-transitive
+
+  security:outdated:
+    desc: List outdated NuGet packages
+    cmds:
+      - dotnet list {{.SOLUTION}} package --outdated
+
+  plugins:publish:
+    desc: Publish all plugins to out/plugins/<name>
+    preconditions:
+      - sh: command -v dotnet >/dev/null
+        msg: "dotnet SDK is required (https://dot.net)"
+    cmds:
+      - |
+        mkdir -p out/plugins
+        for proj in $(find {{.PLUGINS_DIR}} -name '*.csproj' \
+            -not -path '*/Abstractions/*' \
+            -not -path '*/obj/*' \
+            -not -path '*/bin/*'); do
+          name=$(basename "$proj" .csproj)
+          echo "Publishing plugin: $name"
+          dotnet publish "$proj" --configuration Release --output "out/plugins/$name" --nologo
+        done
+
+  plugins:validate:
+    desc: Validate plugin contracts against the loaded assemblies
+    deps: [plugins:publish]
+    cmds:
+      - dotnet build {{.VALIDATOR}} --configuration Release --nologo
+      - |
+        DLL=$(find {{.VALIDATOR}}/bin/Release -name PluginContractValidator.dll | head -n1)
+        dotnet "$DLL" "$(pwd)/out/plugins"
+
+  ci:
+    desc: Run the full local CI pipeline
+    deps:
+      - build
+      - test
+      - format
+      - plugins:validate
+    aliases:
+      - precommit
+
+  clean:
+    desc: Remove build output and staging directories
+    cmds:
+      - dotnet clean {{.SOLUTION}} --nologo
+      - cmd: rm -rf out
+        platforms: [linux, darwin]
+      - cmd: Remove-Item -Recurse -Force out -ErrorAction SilentlyContinue
+        platforms: [windows]
+
+includes:
+  docker:
+    taskfile: ./Taskfile.docker.yml

--- a/tools/PluginContractValidator/PluginAssemblyLoader.cs
+++ b/tools/PluginContractValidator/PluginAssemblyLoader.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using AuthKit.Plugins.Abstractions;
+
+namespace PluginContractValidator.Loading;
+
+/// <summary>
+/// Loads a plugin entry assembly using the same isolation model as the AuthKit host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each plugin resolves its own dependencies through an <see cref="AssemblyDependencyResolver"/>
+/// attached to <see cref="AssemblyLoadContext.Default"/>. The resolver stays attached for the
+/// lifetime of the process so that lazily-loaded dependencies (for example, types referenced
+/// inside <c>CheckHealthAsync</c>) continue to resolve, exactly as in the host.
+/// </para>
+/// <para>
+/// A plugin directory is expected to contain an entry assembly whose file name matches the
+/// directory name. Directories without a matching assembly, or assemblies without a public,
+/// non-abstract <see cref="IAuthKitPlugin"/> implementation with a parameterless constructor,
+/// are reported as load errors rather than thrown.
+/// </para>
+/// </remarks>
+public sealed class PluginAssemblyLoader : IPluginLoader
+{
+    private static readonly List<AssemblyDependencyResolver> Resolvers = new();
+    private static readonly object Gate = new();
+    private static Func<AssemblyLoadContext, AssemblyName, Assembly?>? _handler;
+
+    /// <summary>
+    /// Loads the plugin entry assembly and activates its <see cref="IAuthKitPlugin"/> implementation.
+    /// </summary>
+    /// <param name="entryDll">The full path to the plugin's entry assembly.</param>
+    /// <returns>
+    /// A <see cref="PluginLoadResult"/> containing the loaded plugin, or the errors that
+    /// prevented loading.
+    /// </returns>
+    public PluginLoadResult Load(string entryDll)
+    {
+        var errors = new List<string>();
+
+        try
+        {
+            var resolver = new AssemblyDependencyResolver(entryDll);
+            AttachResolver(resolver);
+
+            Assembly assembly;
+            try
+            {
+                assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(entryDll);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"dependency loading failed: {ex.Message}");
+                return new PluginLoadResult(null, errors);
+            }
+
+            Type? pluginType;
+            try
+            {
+                pluginType = assembly.GetTypes()
+                    .FirstOrDefault(t => t is { IsPublic: true, IsAbstract: false }
+                                        && typeof(IAuthKitPlugin).IsAssignableFrom(t)
+                                        && t.GetConstructor(Type.EmptyTypes) is not null);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"type discovery failed: {ex.Message}");
+                return new PluginLoadResult(null, errors);
+            }
+
+            if (pluginType is null)
+            {
+                errors.Add("no public, non-abstract IAuthKitPlugin implementation with a parameterless constructor");
+                return new PluginLoadResult(null, errors);
+            }
+
+            IAuthKitPlugin instance;
+            try
+            {
+                instance = (IAuthKitPlugin)Activator.CreateInstance(pluginType)!;
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"activation failed: {ex.Message}");
+                return new PluginLoadResult(null, errors);
+            }
+
+            return new PluginLoadResult(new LoadedPlugin(instance, assembly), errors);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"unexpected error: {ex.Message}");
+            return new PluginLoadResult(null, errors);
+        }
+    }
+
+    /// <summary>
+    /// Registers a dependency resolver for <see cref="AssemblyLoadContext.Default"/>, ensuring it
+    /// is attached exactly once for the lifetime of the process.
+    /// </summary>
+    /// <param name="resolver">The dependency resolver associated with a loaded plugin assembly.</param>
+    private static void AttachResolver(AssemblyDependencyResolver resolver)
+    {
+        lock (Gate)
+        {
+            Resolvers.Add(resolver);
+
+            if (_handler is null)
+            {
+                _handler = (context, name) =>
+                {
+                    for (var i = Resolvers.Count - 1; i >= 0; i--)
+                    {
+                        var path = Resolvers[i].ResolveAssemblyToPath(name);
+                        if (path is not null)
+                        {
+                            return context.LoadFromAssemblyPath(path);
+                        }
+                    }
+
+                    return null;
+                };
+
+                AssemblyLoadContext.Default.Resolving += _handler;
+            }
+        }
+    }
+}

--- a/tools/PluginContractValidator/PluginContractValidator.csproj
+++ b/tools/PluginContractValidator/PluginContractValidator.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <AssemblyName>PluginContractValidator</AssemblyName>
+    <RootNamespace>PluginContractValidator</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\src\Plugins\Abstractions\AuthKit.Plugins.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+  </ItemGroup>
+</Project>

--- a/tools/PluginContractValidator/Program.cs
+++ b/tools/PluginContractValidator/Program.cs
@@ -1,0 +1,66 @@
+using PluginContractValidator;
+using PluginContractValidator.Loading;
+using PluginContractValidator.Rules;
+
+var pluginsRoot = args.Length > 0 ? args[0] : "src/Plugins";
+
+if (!Directory.Exists(pluginsRoot))
+{
+    Console.Error.WriteLine($"Plugins root not found: {pluginsRoot}");
+    return 1;
+}
+
+IPluginLoader loader = new PluginAssemblyLoader();
+ContractValidator validator = new ContractValidator(new IPluginContractRule[]
+{
+    new MetadataRule(),
+    new RegistrationRule(),
+    new SecuritySchemesRule(),
+    new MiddlewareRule(),
+    new HealthRule(),
+});
+
+var failures = 0;
+
+foreach (var pluginDir in Directory.GetDirectories(pluginsRoot))
+{
+    var pluginName = Path.GetFileName(pluginDir.TrimEnd(Path.DirectorySeparatorChar));
+    var entryDll = Path.Combine(pluginDir, $"{pluginName}.dll");
+
+    if (!File.Exists(entryDll))
+    {
+        Console.WriteLine($"[SKIP] {pluginName}: entry assembly '{entryDll}' not found");
+        continue;
+    }
+
+    var loadResult = loader.Load(entryDll);
+    if (!loadResult.Succeeded)
+    {
+        failures++;
+        Console.WriteLine($"[FAIL] {pluginName}");
+        foreach (var error in loadResult.Errors)
+        {
+            Console.WriteLine($"   - {error}");
+        }
+
+        continue;
+    }
+
+    var errors = await validator.ValidateAsync(loadResult.Plugin!);
+
+    if (errors.Count == 0)
+    {
+        Console.WriteLine($"[PASS] {pluginName} v{loadResult.Plugin!.Instance.Version}");
+    }
+    else
+    {
+        failures++;
+        Console.WriteLine($"[FAIL] {pluginName}");
+        foreach (var error in errors)
+        {
+            Console.WriteLine($"   - {error}");
+        }
+    }
+}
+
+return failures == 0 ? 0 : 1;

--- a/tools/PluginContractValidator/src/ContractValidator.cs
+++ b/tools/PluginContractValidator/src/ContractValidator.cs
@@ -1,0 +1,36 @@
+namespace PluginContractValidator;
+
+/// <summary>
+/// Runs every registered <see cref="IPluginContractRule"/> against a loaded plugin and
+/// aggregates the resulting contract violations.
+/// </summary>
+/// <remarks>
+/// Rules are executed sequentially; each rule's violations are collected into a single
+/// combined list so the caller sees every problem at once.
+/// </remarks>
+/// <param name="rules">The contract rules to execute for each plugin.</param>
+public sealed class ContractValidator(IEnumerable<IPluginContractRule> rules)
+{
+    private readonly IEnumerable<IPluginContractRule> _rules = rules;
+
+    /// <summary>
+    /// Validates the supplied plugin against all registered rules.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>The aggregated, read-only list of contract violations.</returns>
+    public async Task<IReadOnlyList<string>> ValidateAsync(
+        LoadedPlugin plugin,
+        CancellationToken cancellationToken = default)
+    {
+        var errors = new List<string>();
+
+        foreach (var rule in _rules)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            errors.AddRange(await rule.ValidateAsync(plugin, cancellationToken));
+        }
+
+        return errors;
+    }
+}

--- a/tools/PluginContractValidator/src/IPluginContractRule.cs
+++ b/tools/PluginContractValidator/src/IPluginContractRule.cs
@@ -1,0 +1,26 @@
+namespace PluginContractValidator;
+
+/// <summary>
+/// Validates single contract concern of loaded plugin.
+/// </summary>
+/// <remarks>
+/// Rules are composed by <see cref="ContractValidator"/> and executed independently, so a
+/// failure in one concern does not prevent the others from being evaluated.
+/// </remarks>
+public interface IPluginContractRule
+{
+    /// <summary>
+    /// Gets a human-readable name of the validated contract concern (for example, "Metadata").
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Validates the plugin and returns the list of contract violations.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>
+    /// A read-only list of violation messages. An empty list means the rule passed.
+    /// </returns>
+    Task<IReadOnlyList<string>> ValidateAsync(LoadedPlugin plugin, CancellationToken cancellationToken = default);
+}

--- a/tools/PluginContractValidator/src/IPluginLoader.cs
+++ b/tools/PluginContractValidator/src/IPluginLoader.cs
@@ -1,0 +1,20 @@
+using AuthKit.Plugins.Abstractions;
+
+namespace PluginContractValidator;
+
+/// <summary>
+/// Loads a plugin entry assembly and instantiates its <see cref="IAuthKitPlugin"/> implementation.
+/// </summary>
+public interface IPluginLoader
+{
+    /// <summary>
+    /// Loads the plugin entry assembly located at <paramref name="entryDll"/> and activates its
+    /// <see cref="IAuthKitPlugin"/> implementation.
+    /// </summary>
+    /// <param name="entryDll">The full path to the plugin's entry assembly (named after its directory).</param>
+    /// <returns>
+    /// A <see cref="PluginLoadResult"/> describing the loaded plugin, or the errors encountered
+    /// while loading it.
+    /// </returns>
+    PluginLoadResult Load(string entryDll);
+}

--- a/tools/PluginContractValidator/src/LoadedPlugin.cs
+++ b/tools/PluginContractValidator/src/LoadedPlugin.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using AuthKit.Plugins.Abstractions;
+
+namespace PluginContractValidator;
+
+/// <summary>
+/// Represents a plugin assembly that has been successfully loaded and instantiated
+/// by the validation host.
+/// </summary>
+/// <remarks>
+/// The wrapper keeps both the activated <see cref="IAuthKitPlugin"/> instance and the
+/// <see cref="Assembly"/> it was loaded from, so that individual contract rules can
+/// inspect runtime metadata without re-loading the assembly.
+/// </remarks>
+/// <param name="instance">The activated plugin instance implementing <see cref="IAuthKitPlugin"/>.</param>
+/// <param name="assembly">The assembly the plugin type was loaded from.</param>
+public sealed class LoadedPlugin(IAuthKitPlugin instance, Assembly assembly)
+{
+    /// <summary>
+    /// Gets the activated plugin instance implementing <see cref="IAuthKitPlugin"/>.
+    /// </summary>
+    public IAuthKitPlugin Instance { get; } = instance;
+
+    /// <summary>
+    /// Gets the assembly the plugin type was loaded from.
+    /// </summary>
+    public Assembly Assembly { get; } = assembly;
+}

--- a/tools/PluginContractValidator/src/PluginLoadResult.cs
+++ b/tools/PluginContractValidator/src/PluginLoadResult.cs
@@ -1,0 +1,18 @@
+namespace PluginContractValidator;
+
+/// <summary>
+/// Encapsulates the outcome of attempting to load a plugin assembly.
+/// </summary>
+/// <remarks>
+/// When loading fails, <see cref="Plugin"/> is <c>null</c> and <see cref="Errors"/>
+/// contains the human-readable reasons for the failure.
+/// </remarks>
+/// <param name="Plugin">The loaded plugin, or <c>null</c> when loading failed.</param>
+/// <param name="Errors">The list of contract or loading violations encountered.</param>
+public sealed record PluginLoadResult(LoadedPlugin? Plugin, IReadOnlyList<string> Errors)
+{
+    /// <summary>
+    /// Gets a value indicating whether the plugin was loaded successfully.
+    /// </summary>
+    public bool Succeeded => Plugin is not null;
+}

--- a/tools/PluginContractValidator/src/Rules/HealthRule.cs
+++ b/tools/PluginContractValidator/src/Rules/HealthRule.cs
@@ -1,0 +1,44 @@
+using AuthKit.Plugins.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PluginContractValidator.Rules;
+
+/// <summary>
+/// Ensures <c>CheckHealthAsync</c> does not throw when invoked against a built service
+/// provider (the host treats a throwing health check as a contract violation).
+/// </summary>
+public sealed class HealthRule : IPluginContractRule
+{
+    /// <summary>Gets the rule name ("Health").</summary>
+    public string Name => "Health";
+
+    /// <summary>
+    /// Builds a service provider from the plugin's registered services and invokes
+    /// <see cref="IAuthKitPlugin.CheckHealthAsync"/>, capturing any thrown exception as a violation.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>The list of health check violations; empty when the check completes without throwing.</returns>
+    public async Task<IReadOnlyList<string>> ValidateAsync(
+        LoadedPlugin plugin,
+        CancellationToken cancellationToken = default)
+    {
+        var errors = new List<string>();
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        plugin.Instance.ConfigureServices(services, configuration);
+
+        try
+        {
+            await using var provider = services.BuildServiceProvider();
+            await plugin.Instance.CheckHealthAsync(provider);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"health: CheckHealthAsync threw (must not throw): {ex.Message}");
+        }
+
+        return errors;
+    }
+}

--- a/tools/PluginContractValidator/src/Rules/MetadataRule.cs
+++ b/tools/PluginContractValidator/src/Rules/MetadataRule.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+using AuthKit.Plugins.Abstractions;
+
+namespace PluginContractValidator.Rules;
+
+/// <summary>
+/// Ensures plugin metadata (Name, Version) is present and well-formed.
+/// </summary>
+/// <remarks>
+/// The rule verifies that <see cref="IAuthKitPlugin.Name"/> is non-empty and that
+/// <see cref="IAuthKitPlugin.Version"/> follows the SemVer
+/// (<c>major.minor.patch[-prerelease]</c>) format expected by the host.
+/// </remarks>
+public sealed class MetadataRule : IPluginContractRule
+{
+    private static readonly Regex SemVer =
+        new(@"^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$", RegexOptions.Compiled);
+
+    /// <summary>Gets the rule name ("Metadata").</summary>
+    public string Name => "Metadata";
+
+    /// <summary>
+    /// Validates the plugin's metadata.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>The list of metadata violations; empty when the metadata is valid.</returns>
+    public Task<IReadOnlyList<string>> ValidateAsync(
+        LoadedPlugin plugin,
+        CancellationToken cancellationToken = default)
+    {
+        var pluginInstance = plugin.Instance;
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(pluginInstance.Name))
+        {
+            errors.Add("metadata: Name is null or empty");
+        }
+
+        if (string.IsNullOrWhiteSpace(pluginInstance.Version))
+        {
+            errors.Add("metadata: Version is null or empty");
+        }
+        else if (!SemVer.IsMatch(pluginInstance.Version))
+        {
+            errors.Add($"metadata: Version '{pluginInstance.Version}' is not SemVer (expected major.minor.patch[-prerelease])");
+        }
+
+        return Task.FromResult<IReadOnlyList<string>>(errors);
+    }
+}

--- a/tools/PluginContractValidator/src/Rules/MiddlewareRule.cs
+++ b/tools/PluginContractValidator/src/Rules/MiddlewareRule.cs
@@ -1,0 +1,64 @@
+using AuthKit.Plugins.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace PluginContractValidator.Rules;
+
+/// <summary>
+/// Ensures a contributed middleware type follows the ASP.NET Core middleware convention.
+/// </summary>
+/// <remarks>
+/// The middleware type must expose a constructor accepting
+/// <see cref="RequestDelegate"/> and an <c>InvokeAsync(HttpContext, ...)</c> method that returns
+/// <see cref="Task"/>, mirroring the conventional ASP.NET Core middleware shape.
+/// </remarks>
+public sealed class MiddlewareRule : IPluginContractRule
+{
+    /// <summary>Gets the rule name ("Middleware").</summary>
+    public string Name => "Middleware";
+
+    /// <summary>
+    /// Validates the middleware type contributed by <see cref="IAuthKitPlugin.MiddlewareType"/>,
+    /// if any.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>
+    /// The list of middleware violations; empty when the middleware is valid or absent.
+    /// </returns>
+    public Task<IReadOnlyList<string>> ValidateAsync(
+        LoadedPlugin plugin,
+        CancellationToken cancellationToken = default)
+    {
+        var errors = new List<string>();
+        var middlewareType = plugin.Instance.MiddlewareType;
+
+        if (middlewareType is null)
+        {
+            return Task.FromResult<IReadOnlyList<string>>(errors);
+        }
+
+        var hasRequestDelegateCtor = middlewareType.GetConstructors()
+            .Any(c => c.GetParameters().Any(p => p.ParameterType == typeof(RequestDelegate)));
+
+        if (!hasRequestDelegateCtor)
+        {
+            errors.Add($"middleware: MiddlewareType '{middlewareType.Name}' does not have a constructor accepting RequestDelegate");
+        }
+
+        var invoke = middlewareType.GetMethod("InvokeAsync");
+        if (invoke is null || invoke.ReturnType != typeof(Task))
+        {
+            errors.Add($"middleware: MiddlewareType '{middlewareType.Name}' must expose InvokeAsync returning Task");
+        }
+        else
+        {
+            var parameters = invoke.GetParameters();
+            if (parameters.Length == 0 || parameters[0].ParameterType != typeof(HttpContext))
+            {
+                errors.Add($"middleware: InvokeAsync on '{middlewareType.Name}' must take HttpContext as its first parameter");
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<string>>(errors);
+    }
+}

--- a/tools/PluginContractValidator/src/Rules/RegistrationRule.cs
+++ b/tools/PluginContractValidator/src/Rules/RegistrationRule.cs
@@ -1,0 +1,53 @@
+using AuthKit.Plugins.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PluginContractValidator.Rules;
+
+/// <summary>
+/// Ensures <c>ConfigureServices</c> registers dependencies without throwing and that the
+/// resulting service container can be built (dependency wiring is valid).
+/// </summary>
+public sealed class RegistrationRule : IPluginContractRule
+{
+    /// <summary>Gets the rule name ("Registration").</summary>
+    public string Name => "Registration";
+
+    /// <summary>
+    /// Invokes <see cref="IAuthKitPlugin.ConfigureServices"/> against a fresh service collection
+    /// and then builds the <see cref="IServiceProvider"/> to confirm the dependency graph is
+    /// constructible.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>The list of registration violations; empty when registration succeeds.</returns>
+    public Task<IReadOnlyList<string>> ValidateAsync(
+        LoadedPlugin plugin,
+        CancellationToken cancellationToken = default)
+    {
+        var errors = new List<string>();
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        try
+        {
+            plugin.Instance.ConfigureServices(services, configuration);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"registration: ConfigureServices threw: {ex.Message}");
+            return Task.FromResult<IReadOnlyList<string>>(errors);
+        }
+
+        try
+        {
+            services.BuildServiceProvider();
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"registration: service provider build failed (bad dependency wiring): {ex.Message}");
+        }
+
+        return Task.FromResult<IReadOnlyList<string>>(errors);
+    }
+}

--- a/tools/PluginContractValidator/src/Rules/SecuritySchemesRule.cs
+++ b/tools/PluginContractValidator/src/Rules/SecuritySchemesRule.cs
@@ -1,0 +1,59 @@
+using AuthKit.Plugins.Abstractions;
+
+namespace PluginContractValidator.Rules;
+
+/// <summary>
+/// Ensures contributed OpenAPI security schemes are well-formed.
+/// </summary>
+/// <remarks>
+/// The rule verifies that the dictionary returned by
+/// <see cref="IAuthKitPlugin.GetSecuritySchemes"/> is not <c>null</c> and that each key
+/// matches the <c>Name</c> of its
+/// <see cref="AuthKit.Plugins.Abstractions.AuthKitSecuritySchemeDescriptor"/>.
+/// </remarks>
+public sealed class SecuritySchemesRule : IPluginContractRule
+{
+    /// <summary>Gets the rule name ("SecuritySchemes").</summary>
+    public string Name => "SecuritySchemes";
+
+    /// <summary>
+    /// Validates the security schemes contributed by the plugin.
+    /// </summary>
+    /// <param name="plugin">The loaded plugin to validate.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the validation.</param>
+    /// <returns>The list of security-scheme violations; empty when the schemes are valid.</returns>
+    public Task<IReadOnlyList<string>> ValidateAsync(
+        LoadedPlugin plugin,
+        CancellationToken cancellationToken = default)
+    {
+        var errors = new List<string>();
+
+        try
+        {
+            var schemes = plugin.Instance.GetSecuritySchemes();
+            if (schemes is null)
+            {
+                errors.Add("security schemes: GetSecuritySchemes returned null");
+                return Task.FromResult<IReadOnlyList<string>>(errors);
+            }
+
+            foreach (var pair in schemes)
+            {
+                if (pair.Value is null)
+                {
+                    errors.Add($"security schemes: scheme '{pair.Key}' has a null descriptor");
+                }
+                else if (pair.Key != pair.Value.Name)
+                {
+                    errors.Add($"security schemes: key '{pair.Key}' does not match descriptor Name '{pair.Value.Name}'");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"security schemes: GetSecuritySchemes threw: {ex.Message}");
+        }
+
+        return Task.FromResult<IReadOnlyList<string>>(errors);
+    }
+}


### PR DESCRIPTION
This PR adds CI pipelines, plugin contract validator, and local task runner so that
plugin and image changes are verified automatically and consistently before they reach
`main`.

- adds three GitHub workflows: `security.yml`, `docker.yml`, and `plugin-validation.yml`
- adds the `PluginContractValidator` tool that verifies the `IAuthKitPlugin` contract
- adds `Taskfile.yml` (with a `Taskfile.docker.yml` include) wrapping all local checks
- documents the validator and extends `.gitignore`

## Security Workflow (`security.yml`)

- runs on `main`, `development`, PRs, and a weekly schedule
- **light scans on every branch/PR**: NuGet audit, CodeQL (`security extended`), TruffleHog secret scan, `dotnet format` check
- **release only jobs on `main`**: license compliance, SBOM generation + attestation, Trivy container scan
- uploads SARIF to GitHub code scanning where applicable

## Docker Workflow (`docker.yml`)

- triggers only on `release: published` and `v*` tags (never on every PR)
- three stage pipeline: **build** -> **smoke test** (container starts, HTTP check) -> **publish**
- pushes `ghcr.io/authkits/authkit.server` with `semver` + `latest` tags, multi-arch (`linux/amd64`, `linux/arm64`)
- image is built with embedded **provenance and SBOM**

## Plugin Contract Validation (`plugin-validation.yml` + `tools/PluginContractValidator`)

- publishes every plugin and runs the contract validator on `development`/`main` PRs and tags
- the validator loads plugins with the **same isolation model as the host** (`AssemblyDependencyResolver` + `AssemblyLoadContext.Default`) and asserts:
  - **metadata** - non empty `Name`, SemVer `Version`
  - **registration** - `ConfigureServices` does not throw and the `IServiceProvider` builds
  - **security schemes** - `GetSecuritySchemes()` keys match descriptor names
  - **middleware** - `MiddlewareType` follows the ASP.NET Core convention
  - **health** - `CheckHealthAsync` does not throw
- follows: `IPluginLoader` / `IPluginContractRule` / `ContractValidator` with one rule per concern new rules are added without touching the validator
- ships with `tools/PluginContractValidator/README.md`

## Developer Task Runner (`Taskfile.yml`)

- `includes` a `Taskfile.docker.yml` for image tasks
- orchestrates `restore` -> `build` -> `test` → `format` -> `plugins:validate` via `deps`
- uses `preconditions`, `prompt` (before push), `watch` (test loop), `sources` / `generates` (incremental), `aliases` (`ci` ↔ `precommit`), and `platforms` (cross platform `clean`)
- `task plugins:validate` reproduces the CI contract check locally

## Other

- `.gitignore` now ignores `/out/` (generated by `plugins:publish`)

## Result

- plugin and image changes are gated by automated contract, security, and build checks
- contributors can run the full local CI with single `task ci` (or `task precommit`)
- releasing produces a scanned, attested, multi arch image in GHCR without manual steps
